### PR TITLE
Export commonjs jst

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ gulp.task('JST', function () {
   gulp.src('client/app/views/**/*jade')
     .pipe(jade())
     .pipe(jstConcat('jst.js', {
-      renameKeys: ['^.*views/(.*).html$', '$1']
+      renameKeys: ['^.*views/(.*).html$', '$1'],
+      exportString: "this.JST"
     }))
     .pipe(gulp.dest('public/assets'))
 })
@@ -35,6 +36,8 @@ Given the example's option `renameKeys: ['^.*views/(.*).html$', '$1']` those vie
 will now be accessible as compiled [lodash](http://lodash.com/docs#template) template functions via
 - `JST['foo']` and
 - `JST['bar/baz']`.
+
+The `exportString` option makes it possible to put your compiled JST on to any object within your compiled template file. You can specify any object that is accessible to the file, `window.JST` or `module.exports` if you want to use it with browserify.
 
 (Please note that `gulp-jst-concat` doesn't have to be used in conjunction with `gulp-jade`. Any input-stream emitting html-ish file contents will do.)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,13 +30,16 @@ function buildJSTString(files, opts) {
     return printf('"%s": %s', template.name, template.fnSource)
   }
 
-  return printf('this.JST = {%s};', files.map(compileAndRender).join(',\n'))
+  return printf('%s = {%s};', opts.exportString, files.map(compileAndRender).join(',\n'))
 }
 
 module.exports = function jstConcat(fileName, _opts) {
   if (!fileName) throw pluginError('Missing fileName')
 
-  var defaults = { renameKeys: ['.*', '$&'] }
+  var defaults = { 
+      renameKeys: ['.*', '$&'],
+      exportString: "this.JST"
+    }
     , opts = _.extend({}, defaults, _opts)
     , files = []
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,8 @@ function pluginError (message) {
   return new PluginError('gulp-jst-concat', message)
 }
 
-function compile (file, renameKeys) {
+function compile (file, opts) {
+  var renameKeys = opts.renameKeys;
   var name = file.path.replace(new RegExp(renameKeys[0]), renameKeys[1])
     , contents = String(file.contents)
 
@@ -22,7 +23,8 @@ function compile (file, renameKeys) {
   }
 }
 
-function buildJSTString(files, renameKeys) {
+function buildJSTString(files, opts) {
+  var renameKeys = opts.renameKeys;
   function compileAndRender (file) {
     var template = compile(file, renameKeys)
     return printf('"%s": %s', template.name, template.fnSource)
@@ -48,7 +50,7 @@ module.exports = function jstConcat(fileName, _opts) {
 
   function end () {
     /* jshint validthis: true */
-    var jstString = buildJSTString(files, opts.renameKeys)
+    var jstString = buildJSTString(files, opts)
 
     this.queue(new File({
       path: fileName,


### PR DESCRIPTION
Added a new option to place the JST object on something other than `this.JST`
